### PR TITLE
Trigger on pull_request_target

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  pull_request_target:
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
In this [PR#18](https://github.com/hyperledger/firefly-tezosconnect/pull/18) codecov wasn't triggered in comparison with this [PR#17](https://github.com/hyperledger/firefly-tezosconnect/pull/17)

This issue were described [here](https://github.com/codecov/codecov-action/issues/29) 

Solution is [pull_request_target](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks)

> In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. This event can be used in combination with the private repository settings as well.

Important note it seems it works only for PR from main to main as mentioned [here](https://github.com/preactjs/compressed-size-action/issues/54) 