### PR TITLE
Fix flaky test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MOCKERY := $(GOBIN)/mockery
 
 all: build test go-mod-tidy
 test: deps
-		$(VGO) test ./internal/... ./cmd/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s
+		$(VGO) test ./internal/... ./cmd/... -v -short -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s
 coverage.html:
 		$(VGO) tool cover -html=coverage.txt
 coverage: test coverage.html

--- a/internal/tezos/new_block_listener_test.go
+++ b/internal/tezos/new_block_listener_test.go
@@ -2,6 +2,7 @@ package tezos
 
 import (
 	"testing"
+	"time"
 
 	"blockwatch.cc/tzgo/rpc"
 	"blockwatch.cc/tzgo/tezos"
@@ -11,7 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestNewBlockListenerOK(t *testing.T) {
+func TestNewBlockListenerOKWithDelay(t *testing.T) {
 	ctx, c, mRPC, done := newTestConnector(t)
 	defer done()
 
@@ -24,13 +25,17 @@ func TestNewBlockListenerOK(t *testing.T) {
 				Level:       12345,
 			},
 		}, nil).Maybe()
+	mRPC.On("MonitorBlockHeader", mock.Anything, mock.Anything).Return(nil)
 
 	req := &ffcapi.NewBlockListenerRequest{
 		ID:              fftypes.NewUUID(),
 		ListenerContext: ctx,
 		BlockListener:   make(chan<- *ffcapi.BlockHashEvent),
 	}
+
 	res, _, err := c.NewBlockListener(ctx, req)
+
+	time.Sleep(1 * time.Second)
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
 }

--- a/internal/tezos/retry_delay_test.go
+++ b/internal/tezos/retry_delay_test.go
@@ -16,9 +16,7 @@ func TestRetryDelay(t *testing.T) {
 	c.retry.InitialDelay = 1 * time.Microsecond
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		cancel()
-	}()
+	cancel()
 
 	testCases := []struct {
 		name         string


### PR DESCRIPTION
Build is failed time to time due test https://github.com/hyperledger/firefly-tezosconnect/actions/runs/6794181484/job/18470172130

1) Can reproduce failed behaviour if add additional sleep before done() execution, see test for reproducing the issue and fix for existing   
2) Since we can't identify which one test is failed, added option -v (verbose) it should show passed and failed names of tests. 