### PR TITLE
Fix write permissions

### DIFF
--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   docker:

--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -13,6 +13,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
 
+    permissions:
+      packages: write
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -6,11 +6,13 @@ on:
     
 permissions:
   contents: read
-  packages: write
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
       
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  packages: write  
 
 jobs:
   build:


### PR DESCRIPTION
[3 issues were resolved](https://github.com/hyperledger/firefly-tezosconnect/security/code-scanning?query=is%3Aclosed+branch%3Amain) after fixing #64 but appeared
https://github.com/hyperledger/firefly-tezosconnect/security/code-scanning/32
https://github.com/hyperledger/firefly-tezosconnect/security/code-scanning/31
https://github.com/hyperledger/firefly-tezosconnect/security/code-scanning/30

The main reason is 
`Set any required write permissions at the job-level`

So put `packages: write` under `jobs`, suppose for `go.yml` we don't need write
