### PR TITLE
Update outdated SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,19 +2,10 @@
 
 ## Reporting a Security Bug
 
-If you think you have discovered a security issue in any of the Hyperledger projects, we'd love to
-hear from you. We will take all security bugs seriously and if confirmed upon investigation we will
-patch it within a reasonable amount of time and release a public security bulletin discussing the
-impact and credit the discoverer.
+If you think you have discovered a security issue in any of the Hyperledger projects, we'd love to hear from you. We will take all security bugs seriously and if confirmed upon investigation we will patch it within a reasonable amount of time and release a public security bulletin discussing the impact and credit the discoverer.
 
-There are two ways to report a security bug. The easiest is to email a description of the flaw and
-any related information (e.g. reproduction steps, version) to
-[security at hyperledger dot org](mailto:security@hyperledger.org).
+There are two ways to report a security bug. The easiest is to email a description of the flaw and any related information (e.g. reproduction steps, version) to [security at hyperledger dot org](mailto:security@hyperledger.org).
 
-The other way is to file a confidential security bug in our
-[JIRA bug tracking system](https://jira.hyperledger.org). Be sure to set the “Security Level” to
-“Security issue”.
+The other way is to file a confidential security bug in the repository's [security advisories page](https://github.com/hyperledger/firefly-tezosconnect/security/advisories). Guidance can be found in the GitHub documentation on [privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).
 
-The process by which the Hyperledger Security Team handles security bugs is documented further in
-our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our
-[wiki](https://wiki.hyperledger.org).
+The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://lf-hyperledger.atlassian.net/wiki/spaces/SEC/pages/20283618/Defect+Response) on our [wiki](https://lf-hyperledger.atlassian.net/wiki).


### PR DESCRIPTION
Update outdated SECURITY.md to sync with other LF repos since some of links outdated for current. Also it helps to [fix Security-Policy issue](https://github.com/hyperledger/firefly-tezosconnect/security/code-scanning/29) slightly improving score openssf scorecard
Related hyperledger/firefly/pull/1677