### PR TITLE
Chore/org migration go 1.26

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -5,7 +5,7 @@
 repository:
   name: firefly-tezosconnect
   description: Firefly Tezos Connect
-  homepage: https://github.com/hyperledger/firefly-tezosconnect
+  homepage: https://github.com/hyperledger-firefly/firefly-tezosconnect
   default_branch: main
   has_downloads: true
   has_issues: true

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,9 +3,9 @@
 #
 
 repository:
-  name: firefly-tezosconnect
+  name: tezosconnect
   description: Firefly Tezos Connect
-  homepage: https://github.com/hyperledger-firefly/firefly-tezosconnect
+  homepage: https://github.com/hyperledger-firefly/tezosconnect
   default_branch: main
   has_downloads: true
   has_issues: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.23.0'
+          go-version: '1.26.0'
 
       - name: Build and Test
         run: make

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26.0'
+          go-version: '1.26'
 
       - name: Build and Test
         run: make

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.6.2
+          version: v2.12.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
 
-See [FireFly Tezos Connector Releases](https://github.com/hyperledger/firefly-tezosconnect/releases)
+See [FireFly Tezos Connector Releases](https://github.com/hyperledger-firefly/firefly-tezosconnect/releases)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
 
-See [FireFly Tezos Connector Releases](https://github.com/hyperledger-firefly/firefly-tezosconnect/releases)
+See [FireFly Tezos Connector Releases](https://github.com/hyperledger-firefly/tezosconnect/releases)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine AS builder
+FROM golang:1.26.0-alpine AS builder
 RUN apk add make
 ARG BUILD_VERSION
 ENV BUILD_VERSION=${BUILD_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,4 @@ deps:
 reference:
 		$(VGO) test ./cmd -timeout=10s -tags docs
 docker:
-		docker build --build-arg BUILD_VERSION=${BUILD_VERSION} ${DOCKER_ARGS} -t hyperledger/firefly-tezosconnect .
+		docker build --build-arg BUILD_VERSION=${BUILD_VERSION} ${DOCKER_ARGS} -t hyperledger-firefly/firefly-tezosconnect .

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint: ${LINT}
 ${MOCKERY}:
 		$(VGO) install github.com/vektra/mockery/v2@v2.43.0
 ${LINT}:
-		$(VGO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
+		$(VGO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 mockpaths:
 		$(eval FFTM_PATH := $(shell $(VGO) list -f '{{.Dir}}' github.com/hyperledger/firefly-transaction-manager/pkg/fftm))
 		$(eval TEZOS_CLIENT_PATH := $(shell $(VGO) list -f '{{.Dir}}' github.com/trilitech/tzgo/rpc))

--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,4 @@ deps:
 reference:
 		$(VGO) test ./cmd -timeout=10s -tags docs
 docker:
-		docker build --build-arg BUILD_VERSION=${BUILD_VERSION} ${DOCKER_ARGS} -t hyperledger-firefly/firefly-tezosconnect .
+		docker build --build-arg BUILD_VERSION=${BUILD_VERSION} ${DOCKER_ARGS} -t hyperledger-firefly/tezosconnect .

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![build](https://github.com/hyperledger/firefly-tezosconnect/actions/workflows/go.yml/badge.svg?branch=main&event=push)](https://github.com/hyperledger/firefly-tezosconnect/actions/workflows/go.yml?branch=main&event=push)
-[![codecov](https://codecov.io/gh/hyperledger/firefly-tezosconnect/branch/main/graph/badge.svg)](https://codecov.io/gh/hyperledger/firefly-tezosconnect)
-[![Go Report Card](https://goreportcard.com/badge/github.com/hyperledger/firefly-tezosconnect)](https://goreportcard.com/report/github.com/hyperledger/firefly-tezosconnect)
-[![Hits-of-Code](https://hitsofcode.com/github/hyperledger/firefly-tezosconnect?branch=main)](https://hitsofcode.com/view/github/hyperledger/firefly-tezosconnect?branch=main)
-[![Go Reference](https://pkg.go.dev/badge/github.com/hyperledger/firefly-tezosconnect.svg)](https://pkg.go.dev/github.com/hyperledger/firefly-tezosconnect)
-[![License](https://img.shields.io/badge/apache-2.0-blue.svg)](https://github.com/hyperledger/firefly-tezosconnect/blob/main/LICENSE)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hyperledger/firefly-tezosconnect/badge)](https://scorecard.dev/viewer/?uri=github.com/hyperledger/firefly-tezosconnect)
+[![build](https://github.com/hyperledger-firefly/firefly-tezosconnect/actions/workflows/go.yml/badge.svg?branch=main&event=push)](https://github.com/hyperledger-firefly/firefly-tezosconnect/actions/workflows/go.yml?branch=main&event=push)
+[![codecov](https://codecov.io/gh/hyperledger-firefly/firefly-tezosconnect/branch/main/graph/badge.svg)](https://codecov.io/gh/hyperledger-firefly/firefly-tezosconnect)
+[![Go Report Card](https://goreportcard.com/badge/github.com/hyperledger-firefly/firefly-tezosconnect)](https://goreportcard.com/report/github.com/hyperledger-firefly/firefly-tezosconnect)
+[![Hits-of-Code](https://hitsofcode.com/github/hyperledger-firefly/firefly-tezosconnect?branch=main)](https://hitsofcode.com/view/github/hyperledger-firefly/firefly-tezosconnect?branch=main)
+[![Go Reference](https://pkg.go.dev/badge/github.com/hyperledger-firefly/firefly-tezosconnect.svg)](https://pkg.go.dev/github.com/hyperledger-firefly/firefly-tezosconnect)
+[![License](https://img.shields.io/badge/apache-2.0-blue.svg)](https://github.com/hyperledger-firefly/firefly-tezosconnect/blob/main/LICENSE)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hyperledger-firefly/firefly-tezosconnect/badge)](https://scorecard.dev/viewer/?uri=github.com/hyperledger-firefly/firefly-tezosconnect)
 
 # Hyperledger FireFly Tezos Connector
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![build](https://github.com/hyperledger-firefly/firefly-tezosconnect/actions/workflows/go.yml/badge.svg?branch=main&event=push)](https://github.com/hyperledger-firefly/firefly-tezosconnect/actions/workflows/go.yml?branch=main&event=push)
-[![codecov](https://codecov.io/gh/hyperledger-firefly/firefly-tezosconnect/branch/main/graph/badge.svg)](https://codecov.io/gh/hyperledger-firefly/firefly-tezosconnect)
-[![Go Report Card](https://goreportcard.com/badge/github.com/hyperledger-firefly/firefly-tezosconnect)](https://goreportcard.com/report/github.com/hyperledger-firefly/firefly-tezosconnect)
-[![Hits-of-Code](https://hitsofcode.com/github/hyperledger-firefly/firefly-tezosconnect?branch=main)](https://hitsofcode.com/view/github/hyperledger-firefly/firefly-tezosconnect?branch=main)
-[![Go Reference](https://pkg.go.dev/badge/github.com/hyperledger-firefly/firefly-tezosconnect.svg)](https://pkg.go.dev/github.com/hyperledger-firefly/firefly-tezosconnect)
-[![License](https://img.shields.io/badge/apache-2.0-blue.svg)](https://github.com/hyperledger-firefly/firefly-tezosconnect/blob/main/LICENSE)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hyperledger-firefly/firefly-tezosconnect/badge)](https://scorecard.dev/viewer/?uri=github.com/hyperledger-firefly/firefly-tezosconnect)
+[![build](https://github.com/hyperledger-firefly/tezosconnect/actions/workflows/go.yml/badge.svg?branch=main&event=push)](https://github.com/hyperledger-firefly/tezosconnect/actions/workflows/go.yml?branch=main&event=push)
+[![codecov](https://codecov.io/gh/hyperledger-firefly/tezosconnect/branch/main/graph/badge.svg)](https://codecov.io/gh/hyperledger-firefly/tezosconnect)
+[![Go Report Card](https://goreportcard.com/badge/github.com/hyperledger-firefly/tezosconnect)](https://goreportcard.com/report/github.com/hyperledger-firefly/tezosconnect)
+[![Hits-of-Code](https://hitsofcode.com/github/hyperledger-firefly/tezosconnect?branch=main)](https://hitsofcode.com/view/github/hyperledger-firefly/tezosconnect?branch=main)
+[![Go Reference](https://pkg.go.dev/badge/github.com/hyperledger-firefly/tezosconnect.svg)](https://pkg.go.dev/github.com/hyperledger-firefly/tezosconnect)
+[![License](https://img.shields.io/badge/apache-2.0-blue.svg)](https://github.com/hyperledger-firefly/tezosconnect/blob/main/LICENSE)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hyperledger-firefly/tezosconnect/badge)](https://scorecard.dev/viewer/?uri=github.com/hyperledger-firefly/tezosconnect)
 
 # Hyperledger FireFly Tezos Connector
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,6 @@ If you think you have discovered a security issue in any of the Hyperledger proj
 
 There are two ways to report a security bug. The easiest is to email a description of the flaw and any related information (e.g. reproduction steps, version) to [security at hyperledger dot org](mailto:security@hyperledger.org).
 
-The other way is to file a confidential security bug in the repository's [security advisories page](https://github.com/hyperledger-firefly/firefly-tezosconnect/security/advisories). Guidance can be found in the GitHub documentation on [privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).
+The other way is to file a confidential security bug in the repository's [security advisories page](https://github.com/hyperledger-firefly/tezosconnect/security/advisories). Guidance can be found in the GitHub documentation on [privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).
 
 The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://lf-hyperledger.atlassian.net/wiki/spaces/SEC/pages/20283618/Defect+Response) on our [wiki](https://lf-hyperledger.atlassian.net/wiki).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,6 @@ If you think you have discovered a security issue in any of the Hyperledger proj
 
 There are two ways to report a security bug. The easiest is to email a description of the flaw and any related information (e.g. reproduction steps, version) to [security at hyperledger dot org](mailto:security@hyperledger.org).
 
-The other way is to file a confidential security bug in the repository's [security advisories page](https://github.com/hyperledger/firefly-tezosconnect/security/advisories). Guidance can be found in the GitHub documentation on [privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).
+The other way is to file a confidential security bug in the repository's [security advisories page](https://github.com/hyperledger-firefly/firefly-tezosconnect/security/advisories). Guidance can be found in the GitHub documentation on [privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).
 
 The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://lf-hyperledger.atlassian.net/wiki/spaces/SEC/pages/20283618/Defect+Response) on our [wiki](https://lf-hyperledger.atlassian.net/wiki).

--- a/cmd/tezosconnect.go
+++ b/cmd/tezosconnect.go
@@ -7,10 +7,10 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/hyperledger-firefly/tezosconnect/internal/tezos"
 	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger-firefly/tezosconnect/internal/tezos"
 	fftmcmd "github.com/hyperledger/firefly-transaction-manager/cmd"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/fftm"
 	txhandlerfactory "github.com/hyperledger/firefly-transaction-manager/pkg/txhandler/registry"

--- a/cmd/tezosconnect.go
+++ b/cmd/tezosconnect.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger/firefly-tezosconnect/internal/tezos"
+	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/tezos"
 	fftmcmd "github.com/hyperledger/firefly-transaction-manager/cmd"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/fftm"
 	txhandlerfactory "github.com/hyperledger/firefly-transaction-manager/pkg/txhandler/registry"

--- a/cmd/tezosconnect.go
+++ b/cmd/tezosconnect.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/tezos"
+	"github.com/hyperledger-firefly/tezosconnect/internal/tezos"
 	fftmcmd "github.com/hyperledger/firefly-transaction-manager/cmd"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/fftm"
 	txhandlerfactory "github.com/hyperledger/firefly-transaction-manager/pkg/txhandler/registry"

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 	"runtime/debug"
 
 	"github.com/hyperledger/firefly-common/pkg/i18n"
-	"github.com/hyperledger/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 	"runtime/debug"
 
 	"github.com/hyperledger/firefly-common/pkg/i18n"
-	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"runtime/debug"
 
-	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
+	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hyperledger-firefly/firefly-tezosconnect
+module github.com/hyperledger-firefly/tezosconnect
 
 go 1.26.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/hyperledger/firefly-tezosconnect
+module github.com/hyperledger-firefly/firefly-tezosconnect
 
-go 1.23.0
+go 1.26.0
 
-toolchain go1.23.6
+toolchain go1.26.4
 
 require (
 	github.com/hashicorp/golang-lru v0.5.4

--- a/internal/tezos/blocklistener_test.go
+++ b/internal/tezos/blocklistener_test.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/trilitech/tzgo/rpc"
-	"github.com/trilitech/tzgo/tezos"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/trilitech/tzgo/rpc"
+	"github.com/trilitech/tzgo/tezos"
 )
 
 func TestBlockListenerStartGettingHighestBlockRetry(t *testing.T) {

--- a/internal/tezos/deploy_contract_prepare.go
+++ b/internal/tezos/deploy_contract_prepare.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/codec"
 	"github.com/trilitech/tzgo/micheline"

--- a/internal/tezos/deploy_contract_prepare.go
+++ b/internal/tezos/deploy_contract_prepare.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/codec"
 	"github.com/trilitech/tzgo/micheline"

--- a/internal/tezos/deploy_contract_prepare.go
+++ b/internal/tezos/deploy_contract_prepare.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/codec"
 	"github.com/trilitech/tzgo/micheline"

--- a/internal/tezos/deploy_contract_prepare_test.go
+++ b/internal/tezos/deploy_contract_prepare_test.go
@@ -1,9 +1,9 @@
 package tezos
 
 import (
+	"github.com/stretchr/testify/mock"
 	"github.com/trilitech/tzgo/rpc"
 	"github.com/trilitech/tzgo/tezos"
-	"github.com/stretchr/testify/mock"
 	"testing"
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"

--- a/internal/tezos/event_actions.go
+++ b/internal/tezos/event_actions.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
-	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 )
 

--- a/internal/tezos/event_actions.go
+++ b/internal/tezos/event_actions.go
@@ -3,9 +3,9 @@ package tezos
 import (
 	"context"
 
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
-	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 )
 

--- a/internal/tezos/event_actions.go
+++ b/internal/tezos/event_actions.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
-	"github.com/hyperledger/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 )
 

--- a/internal/tezos/exec_query.go
+++ b/internal/tezos/exec_query.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
-	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/micheline"
 	"github.com/trilitech/tzgo/rpc"

--- a/internal/tezos/exec_query.go
+++ b/internal/tezos/exec_query.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
-	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/micheline"
 	"github.com/trilitech/tzgo/rpc"

--- a/internal/tezos/exec_query.go
+++ b/internal/tezos/exec_query.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
-	"github.com/hyperledger/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/micheline"
 	"github.com/trilitech/tzgo/rpc"

--- a/internal/tezos/exec_query_test.go
+++ b/internal/tezos/exec_query_test.go
@@ -5,12 +5,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/trilitech/tzgo/micheline"
-	"github.com/trilitech/tzgo/rpc"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/trilitech/tzgo/micheline"
+	"github.com/trilitech/tzgo/rpc"
 )
 
 func TestQueryInvokeSuccess(t *testing.T) {

--- a/internal/tezos/get_address_balance_test.go
+++ b/internal/tezos/get_address_balance_test.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/trilitech/tzgo/rpc"
-	"github.com/trilitech/tzgo/tezos"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/trilitech/tzgo/rpc"
+	"github.com/trilitech/tzgo/tezos"
 )
 
 func TestGetAddressBalanceOK(t *testing.T) {

--- a/internal/tezos/get_block_info.go
+++ b/internal/tezos/get_block_info.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/rpc"
 	"github.com/trilitech/tzgo/tezos"

--- a/internal/tezos/get_block_info.go
+++ b/internal/tezos/get_block_info.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/rpc"
 	"github.com/trilitech/tzgo/tezos"

--- a/internal/tezos/get_block_info.go
+++ b/internal/tezos/get_block_info.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/rpc"
 	"github.com/trilitech/tzgo/tezos"

--- a/internal/tezos/get_block_info_test.go
+++ b/internal/tezos/get_block_info_test.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/trilitech/tzgo/rpc"
-	"github.com/trilitech/tzgo/tezos"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/trilitech/tzgo/rpc"
+	"github.com/trilitech/tzgo/tezos"
 )
 
 func TestGetBlockInfoByNumberOK(t *testing.T) {

--- a/internal/tezos/get_next_nonce_test.go
+++ b/internal/tezos/get_next_nonce_test.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/trilitech/tzgo/rpc"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/trilitech/tzgo/rpc"
 )
 
 func TestGetNextNonceOK(t *testing.T) {

--- a/internal/tezos/new_block_listener_test.go
+++ b/internal/tezos/new_block_listener_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/trilitech/tzgo/rpc"
-	"github.com/trilitech/tzgo/tezos"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/trilitech/tzgo/rpc"
+	"github.com/trilitech/tzgo/tezos"
 )
 
 func TestNewBlockListenerOKWithDelay(t *testing.T) {

--- a/internal/tezos/prepare_transaction.go
+++ b/internal/tezos/prepare_transaction.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/codec"
 	"github.com/trilitech/tzgo/contract"

--- a/internal/tezos/prepare_transaction.go
+++ b/internal/tezos/prepare_transaction.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/codec"
 	"github.com/trilitech/tzgo/contract"

--- a/internal/tezos/prepare_transaction.go
+++ b/internal/tezos/prepare_transaction.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/codec"
 	"github.com/trilitech/tzgo/contract"

--- a/internal/tezos/prepare_transaction_test.go
+++ b/internal/tezos/prepare_transaction_test.go
@@ -7,14 +7,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/trilitech/tzgo/codec"
-	"github.com/trilitech/tzgo/contract"
-	"github.com/trilitech/tzgo/rpc"
-	"github.com/trilitech/tzgo/tezos"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/trilitech/tzgo/codec"
+	"github.com/trilitech/tzgo/contract"
+	"github.com/trilitech/tzgo/rpc"
+	"github.com/trilitech/tzgo/tezos"
 )
 
 func TestTransactionPrepareSuccess(t *testing.T) {

--- a/internal/tezos/send_transaction_test.go
+++ b/internal/tezos/send_transaction_test.go
@@ -6,12 +6,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/trilitech/tzgo/codec"
-	"github.com/trilitech/tzgo/rpc"
-	"github.com/trilitech/tzgo/tezos"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/trilitech/tzgo/codec"
+	"github.com/trilitech/tzgo/rpc"
+	"github.com/trilitech/tzgo/tezos"
 )
 
 func TestTransactionSendSuccess(t *testing.T) {

--- a/internal/tezos/tezos.go
+++ b/internal/tezos/tezos.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly-common/pkg/retry"
-	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/rpc"
 )

--- a/internal/tezos/tezos.go
+++ b/internal/tezos/tezos.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly-common/pkg/retry"
-	"github.com/hyperledger/firefly-tezosconnect/internal/msgs"
+	"github.com/hyperledger-firefly/firefly-tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/rpc"
 )

--- a/internal/tezos/tezos.go
+++ b/internal/tezos/tezos.go
@@ -6,12 +6,12 @@ import (
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly-common/pkg/retry"
-	"github.com/hyperledger-firefly/tezosconnect/internal/msgs"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/trilitech/tzgo/rpc"
 )

--- a/internal/tezos/tezos_test.go
+++ b/internal/tezos/tezos_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/firefly-common/pkg/config"
-	"github.com/hyperledger-firefly/firefly-tezosconnect/mocks/tzrpcbackendmocks"
+	"github.com/hyperledger-firefly/tezosconnect/mocks/tzrpcbackendmocks"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/tezos/tezos_test.go
+++ b/internal/tezos/tezos_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/firefly-common/pkg/config"
-	"github.com/hyperledger/firefly-tezosconnect/mocks/tzrpcbackendmocks"
+	"github.com/hyperledger-firefly/firefly-tezosconnect/mocks/tzrpcbackendmocks"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/tezos/tezos_test.go
+++ b/internal/tezos/tezos_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger-firefly/tezosconnect/mocks/tzrpcbackendmocks"
+	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/tezosconnect/main.go
+++ b/tezosconnect/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hyperledger/firefly-tezosconnect/cmd"
+	"github.com/hyperledger-firefly/firefly-tezosconnect/cmd"
 )
 
 func main() {

--- a/tezosconnect/main.go
+++ b/tezosconnect/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hyperledger-firefly/firefly-tezosconnect/cmd"
+	"github.com/hyperledger-firefly/tezosconnect/cmd"
 )
 
 func main() {


### PR DESCRIPTION
- Update module path and all references from hyperledger/firefly-tezosconnect
to hyperledger-firefly/firefly-tezosconnect following the org migration.

- Rename the Go module path and all import paths from firefly-tezosconnect
to tezosconnect, update repo URLs in docs/badges/settings, and set the
CI Go version to 1.26.